### PR TITLE
Add env var for CERT_YEARS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 A simple Docker container that uses the keygen.sh and metadata.sh scripts directly from the Shibboleth SP distribution. It then puts the keys and metadata file in /working.
 
 ## To Use
-docker run -v $(pwd)/test:/working -e FQDN=test.domain.tld jhulibraries/saml-sp-metadata-gen:latest 
+docker run -v $(pwd)/test:/working -e CERT_YEARS=1 -e FQDN=test.domain.tld jhulibraries/saml-sp-metadata-gen:latest
+
+CERT_YEARS (optional): The number of years before certificate expires.  Default is 10.
+FQDN: The fully qualified domain name for the idP to redirect back to.  Not a url.
 
 This follows the standard format that the JHU Libraries use, published here: https://wiki.library.jhu.edu/display/SYST/Deploying+Shib+auth+on+a+library+server

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,6 +2,9 @@
 
 # ENV VARS:
 #   - $FQDN
+#   - $CERT_YEARS
 
-/keygen.sh -h $FQDN -y 10 -e https://$FQDN/shibboleth -f -o /working
+YEARS=${CERT_YEARS:-10}
+
+/keygen.sh -h $FQDN -y $YEARS -e https://$FQDN/shibboleth -f -o /working
 /metagen.sh -c sp-cert.pem -h $FQDN -e https://$FQDN/shibboleth > /working/$FQDN.xml


### PR DESCRIPTION
Allows setting lifetime of a cert in years. Default is 10.
Updated README
Fixed newlines at bottom of entrypiont and readme.